### PR TITLE
Add Zip endpoint

### DIFF
--- a/src/Api/Generator/Register.php
+++ b/src/Api/Generator/Register.php
@@ -46,6 +46,12 @@ class Register implements ApiEndpointRegistration {
 					'description'       => 'The path each generated PDF should be saved into in the zip file. Merge tags are supported.',
 					'validate_callback' => new ZipPath(),
 				],
+
+				'concurrency' => [
+					'required'    => true,
+					'type'        => 'integer',
+					'description' => 'The number of concurrent PDFs that should be generated simultaneously.',
+				],
 			],
 		] );
 	}
@@ -65,7 +71,8 @@ class Register implements ApiEndpointRegistration {
 
 		/* Save session config file */
 		$config_saved = $this->save_session_config( $session_path, [
-			'path' => $request->get_param( 'path' ),
+			'path'        => $request->get_param( 'path' ),
+			'concurrency' => $request->get_param( 'concurrency' ),
 		] );
 
 		if ( $config_saved === false ) {

--- a/src/Api/Generator/Zip.php
+++ b/src/Api/Generator/Zip.php
@@ -1,0 +1,85 @@
+<?php
+
+namespace GFPDF\Plugins\BulkGenerator\Api\Generator;
+
+use GFPDF\Plugins\BulkGenerator\Api\ApiEndpointRegistration;
+use GFPDF\Plugins\BulkGenerator\Api\ApiNamespace;
+use GFPDF\Plugins\BulkGenerator\Validation\SessionId;
+use League\Flysystem\Adapter\Local;
+use League\Flysystem\Filesystem;
+use League\Flysystem\ZipArchive\ZipArchiveAdapter;
+
+/**
+ * @package     Gravity PDF Bulk Generator
+ * @copyright   Copyright (c) 2020, Blue Liquid Designs
+ * @license     http://opensource.org/licenses/gpl-2.0.php GNU Public License
+ */
+
+/* Exit if accessed directly */
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+class Zip implements ApiEndpointRegistration {
+
+	protected $save_pdf_path;
+
+	public function __construct( $save_pdf_path ) {
+		$this->save_pdf_path = $save_pdf_path;
+	}
+
+	public function endpoint() {
+		/* @TODO - regex for session ID abstract */
+		register_rest_route( ApiNamespace::V1, '/generator/zip/(?P<sessionId>.+?)', [
+			'methods'  => \WP_REST_Server::CREATABLE,
+			'callback' => [ $this, 'response' ],
+
+			'permission_callback' => function() {
+				$gform = \GPDFAPI::get_form_class();
+
+				/* @TODO - remove */
+				return true;
+
+				return $gform->has_capability( 'gravityforms_view_entries' );
+			},
+
+			'args' => [
+				'sessionId' => [
+					'required'          => true,
+					'type'              => 'string',
+					'description'       => 'An alphanumeric active session ID returned via the ' . ApiNamespace::V1 . '/generator/register/ endpoint.',
+					'validate_callback' => new SessionId( $this->save_pdf_path ),
+				],
+			],
+		] );
+	}
+
+	/* @TODO add logging */
+	public function response( \WP_REST_Request $request ) {
+		$this->save_pdf_path = trailingslashit( $this->save_pdf_path . $request->get_param( 'sessionId' ) );
+		$tmp_path            = $this->save_pdf_path . 'tmp';
+		$zip_path            = $this->save_pdf_path . 'archive.zip';
+
+		try {
+			$local = new Filesystem( new Local( $tmp_path ) );
+			$zip   = new Filesystem( new ZipArchiveAdapter( $zip_path ) );
+
+			$contents = $local->listContents( '', true );
+
+			foreach ( $contents as $info ) {
+				if ( $info['extension'] !== 'pdf' ) {
+					continue;
+				}
+
+				$zip->put( $info['path'], $local->read( $info['path'] ) );
+			}
+
+			$zip = null;
+
+			$misc = \GPDFAPI::get_misc_class();
+			$misc->rmdir( $tmp_path );
+		} catch ( \Exception $e ) {
+			return new WP_Error( $e->getCode(), $e->getMessage(), [ 'status' => 500 ] );
+		}
+	}
+}

--- a/src/bootstrap.php
+++ b/src/bootstrap.php
@@ -12,6 +12,7 @@ use GFPDF\Plugins\BulkGenerator\Api\ApiNamespace;
 use GFPDF\Plugins\BulkGenerator\Api\Generator\Create;
 use GFPDF\Plugins\BulkGenerator\Api\Generator\Download;
 use GFPDF\Plugins\BulkGenerator\Api\Generator\Register;
+use GFPDF\Plugins\BulkGenerator\Api\Generator\Zip;
 use GFPDF\Plugins\BulkGenerator\Api\Search\Entries;
 use GFPDF\Plugins\BulkGenerator\MergeTags\CreatedBy;
 use GFPDF\Plugins\BulkGenerator\MergeTags\DateCreated;
@@ -59,6 +60,7 @@ class Bootstrap extends Helper_Abstract_Addon {
 			new Create( $pdf_save_path ),
 			new Download( $pdf_save_path ),
 			new Entries(),
+			new Zip( $pdf_save_path ),
 		] );
 
 		$mergetag_classes = [];


### PR DESCRIPTION
## Endpoint Changes

All endpoints access JSON and return JSON. 

#### POST: gravity-pdf-bulk-generator/v1/generator/register

Request Data Structure: 
`path`: `string` (required)
**`concurrency`: `integer` (required)**

#### POST: gravity-pdf-bulk-generator/v1/generator/zip/`<sessionId>`

Will zip up any PDFs created so far. Should be used at the end of a batch of concurrent requests. 

Request Data Structure: 
N/A

Response Status: 200
Response Data Structure:
N/A

Response Status: 500 (server permissions error creating zip file)
`code`: `string` (type of error)
