### PR TITLE
Fix Step2 cancel button bug

### DIFF
--- a/src/assets/react/actions/pdf.js
+++ b/src/assets/react/actions/pdf.js
@@ -5,6 +5,7 @@ import {
   TOGGLE_PDF_STATUS,
   GENERATE_SESSION_ID,
   GENERATE_PDF_CANCEL,
+  GENERATE_PDF_TOGGLE_CANCEL,
   RESET_PDF_STATE
 } from '../actionTypes/pdf'
 
@@ -47,6 +48,12 @@ export const generateSessionId = (path, concurrency, retryInterval, delayInterva
 export const generatePdfCancel = () => {
   return {
     type: GENERATE_PDF_CANCEL
+  }
+}
+
+export const generatePdfToggleCancel = () => {
+  return {
+    type: GENERATE_PDF_TOGGLE_CANCEL
   }
 }
 

--- a/src/assets/react/components/PopUp/Index.js
+++ b/src/assets/react/components/PopUp/Index.js
@@ -6,6 +6,7 @@ import { PoseGroup } from 'react-pose'
 import {
   escapeCloseModal,
   generatePdfCancel,
+  generatePdfToggleCancel,
   resetPdfState
 } from '../../actions/pdf'
 import { resetTagPickerState } from '../../actions/tagPicker'
@@ -17,8 +18,10 @@ import Steps from '../Steps/Steps'
 class PopUp extends React.Component {
 
   static propTypes = {
+    downloadPercentage: PropTypes.number.isRequired,
     escapeCloseModal: PropTypes.func.isRequired,
     generatePdfCancel: PropTypes.func.isRequired,
+    generatePdfToggleCancel: PropTypes.func.isRequired,
     resetTagPickerState: PropTypes.func.isRequired,
     resetPdfState: PropTypes.func.isRequired,
     history: PropTypes.object.isRequired,
@@ -32,7 +35,9 @@ class PopUp extends React.Component {
   escapeKeyListener = e => {
     const {
       escapeCloseModal,
+      downloadPercentage,
       generatePdfCancel,
+      generatePdfToggleCancel,
       resetTagPickerState,
       resetPdfState,
       history
@@ -46,11 +51,22 @@ class PopUp extends React.Component {
     }
 
     if (keyCode === escapeKey && pathname === '/step/2') {
-      cancelButton({ escapeCloseModal, generatePdfCancel, history })
+      cancelButton({
+        escapeCloseModal,
+        downloadPercentage,
+        generatePdfCancel,
+        generatePdfToggleCancel,
+        history
+      })
     }
 
     if (keyCode === escapeKey && pathname === '/step/3') {
-      cancelButton({ escapeCloseModal, resetTagPickerState, resetPdfState, history })
+      cancelButton({
+        escapeCloseModal,
+        resetTagPickerState,
+        resetPdfState,
+        history
+      })
     }
   }
 
@@ -65,23 +81,28 @@ class PopUp extends React.Component {
               component={Overlay} />
           </Fade>,
 
-          <SlideDown
-            key='slidedown'
-            id='gfpdf-bulk-generator-popup'>
-            <Route
-              key='steps'
-              path='/step/:stepId'
-              component={Steps} />
-          </SlideDown>
+            <SlideDown
+              key='slidedown'
+              id='gfpdf-bulk-generator-popup'>
+              <Route
+                key='steps'
+                path='/step/:stepId'
+                component={Steps} />
+            </SlideDown>
         )}
       </PoseGroup>
     )
   }
 }
 
-export default connect(null, {
+const mapStateToProps = state => ({
+  downloadPercentage: state.pdf.downloadPercentage
+})
+
+export default connect(mapStateToProps, {
   escapeCloseModal,
   generatePdfCancel,
+  generatePdfToggleCancel,
   resetTagPickerState,
   resetPdfState
 })(PopUp)

--- a/src/assets/react/components/Steps/Step2.js
+++ b/src/assets/react/components/Steps/Step2.js
@@ -2,7 +2,11 @@ import React from 'react'
 import PropTypes from 'prop-types'
 import { connect } from 'react-redux'
 import { CircularProgressbar } from 'react-circular-progressbar'
-import { toggleModal, generatePdfCancel } from '../../actions/pdf'
+import {
+  toggleModal,
+  generatePdfCancel,
+  generatePdfToggleCancel
+} from '../../actions/pdf'
 import LoadingDots from '../LoadingDots'
 import ProgressBar from '../ProgressBar'
 import { cancelButton } from '../../helpers/cancelButton'
@@ -15,6 +19,7 @@ class Step2 extends React.Component {
     downloadZipUrl: PropTypes.string.isRequired,
     toggleModal: PropTypes.func.isRequired,
     generatePdfCancel: PropTypes.func.isRequired,
+    generatePdfToggleCancel: PropTypes.func.isRequired,
     history: PropTypes.object.isRequired
   }
 
@@ -22,11 +27,11 @@ class Step2 extends React.Component {
     document.addEventListener('focus', this.handleFocus, true)
   }
 
-  componentDidUpdate () {
-    this.checkDownloadPercentage()
+  componentDidUpdate (prevProps) {
+    this.checkDownloadPercentage(prevProps)
   }
 
-  componentWillUnmount() {
+  componentWillUnmount () {
     document.removeEventListener('focus', this.handleFocus, true)
   }
 
@@ -36,10 +41,10 @@ class Step2 extends React.Component {
     }
   }
 
-  checkDownloadPercentage = () => {
+  checkDownloadPercentage = (prevProps) => {
     const { downloadPercentage, downloadZipUrl, history } = this.props
 
-    if (downloadPercentage === 100 && downloadZipUrl !== '') {
+    if (downloadPercentage === 100 && prevProps.downloadZipUrl !== downloadZipUrl) {
       setTimeout(() => history.push('/step/3'), 1000)
     }
   }
@@ -49,6 +54,7 @@ class Step2 extends React.Component {
       downloadPercentage,
       toggleModal,
       generatePdfCancel,
+      generatePdfToggleCancel,
       history
     } = this.props
 
@@ -67,7 +73,14 @@ class Step2 extends React.Component {
         <footer>
           <button
             className='button button-large'
-            onClick={e => cancelButton({ e, toggleModal, generatePdfCancel, history })}>
+            onClick={e => cancelButton({
+              e,
+              toggleModal,
+              downloadPercentage,
+              generatePdfCancel,
+              generatePdfToggleCancel,
+              history
+            })}>
             Cancel
           </button>
         </footer>
@@ -82,4 +95,8 @@ const mapStateToProps = state => ({
   downloadZipUrl: state.pdf.downloadZipUrl
 })
 
-export default connect(mapStateToProps, { toggleModal, generatePdfCancel })(Step2)
+export default connect(mapStateToProps, {
+  toggleModal,
+  generatePdfCancel,
+  generatePdfToggleCancel
+})(Step2)

--- a/src/assets/react/helpers/cancelButton.js
+++ b/src/assets/react/helpers/cancelButton.js
@@ -4,7 +4,9 @@ export function cancelButton (
     history,
     toggleModal,
     escapeCloseModal,
+    downloadPercentage,
     generatePdfCancel,
+    generatePdfToggleCancel,
     resetTagPickerState,
     resetPdfState
   }
@@ -20,7 +22,7 @@ export function cancelButton (
     )
   }
 
-  if (pathname === '/step/2') {
+  if (pathname === '/step/2' && downloadPercentage < 100) {
     if (confirm('Are you sure you want to cancel download?')) {
       return (
         e && e.preventDefault(),
@@ -32,6 +34,16 @@ export function cancelButton (
     }
 
     e && e.preventDefault()
+  }
+
+  if (pathname === '/step/2' && downloadPercentage === 100) {
+    return (
+      e && e.preventDefault(),
+      toggleModal && toggleModal(),
+      escapeCloseModal && escapeCloseModal(),
+      generatePdfToggleCancel && generatePdfToggleCancel(),
+      history.push('/step/1')
+    )
   }
 
   if (pathname === '/step/3') {

--- a/src/assets/react/reducers/pdfReducer.js
+++ b/src/assets/react/reducers/pdfReducer.js
@@ -104,7 +104,8 @@ export default function (state = initialState, action) {
         generatePdFailed: [],
         generatePdfCancel: false,
         generatePdfCounter: 0,
-        downloadPercentage: 0
+        downloadPercentage: 0,
+        downloadZipUrl: ''
       }
 
     case GENERATE_PDF_COUNTER: {


### PR DESCRIPTION
Disable native confirm dialog box if cancellation triggered at 100% download percentage and set the correct reducer state.