### PR TITLE
Only retry on 500 and 408 status codes

### DIFF
--- a/src/Api/Generator/Download.php
+++ b/src/Api/Generator/Download.php
@@ -109,7 +109,7 @@ class Download implements ApiEndpointRegistration {
 			/* Verify the zip file still exists, otherwise return error */
 			$zip_path = $this->filesystem->get_zip_path();
 			if ( ! $this->filesystem->has( $zip_path ) ) {
-				return new \WP_Error( 'zip_not_found', [ 'status' => 404 ] );
+				return new \WP_Error( 'zip_not_found', '', [ 'status' => 404 ] );
 			}
 
 			/* Send zip file to browser */
@@ -127,7 +127,7 @@ class Download implements ApiEndpointRegistration {
 			$this->filesystem->deleteDir( $this->filesystem->get_tmp_basepath() );
 		} catch ( \Exception $e ) {
 			$this->logger->error( $e->getMessage(), [ 'session' => $request->get_param( 'sessionId' ) ] );
-			return new \WP_Error( $e->getMessage(), [ 'status' => 500 ] );
+			return new \WP_Error( $e->getMessage(), '', [ 'status' => 500 ] );
 		}
 
 		$this->end();

--- a/src/Api/Generator/Register.php
+++ b/src/Api/Generator/Register.php
@@ -117,7 +117,7 @@ class Register implements ApiEndpointRegistration {
 		/* Create tmp Session directory */
 		if ( ! $this->filesystem->createDir( $session_id ) ) {
 			$this->logger->error( 'Could not create temporary session directory', [ 'session' => $request->get_param( 'sessionId' ) ] );
-			return new \WP_Error( 'error_creating_path', [ 'status' => 500 ] );
+			return new \WP_Error( 'error_creating_path', '', [ 'status' => 500 ] );
 		}
 
 		/* Save session config file */
@@ -132,7 +132,7 @@ class Register implements ApiEndpointRegistration {
 						 ->save();
 		} catch ( BulkPdfGenerator $e ) {
 			$this->logger->error( 'Could not create session config file', [ 'session' => $request->get_param( 'sessionId' ) ] );
-			return new \WP_Error( 'error_creating_config', [ 'status' => 500 ] );
+			return new \WP_Error( 'error_creating_config', '', [ 'status' => 500 ] );
 		}
 		return [
 			'sessionId' => $session_id,

--- a/src/assets/react/api/api.js
+++ b/src/assets/react/api/api.js
@@ -6,26 +6,22 @@
  */
 
 /**
- * Wrapper for the fetch() API which throws an error when the response isn't `.ok`
+ * Wrapper for the fetch() API which return a promise reject for some status codes
  *
  * @param string url
  * @param object init
+ *
  * @returns {Promise<Response>}
  *
  * @since 1.0
  */
 export const api = async (url, init) => {
   const response = await fetch(url, init)
-  let result
 
-  /* If response.ok is false, return an error */
-  if (!response.ok) {
-    result = await response.json()
-
-    return throw new Error(JSON.stringify({ response: result.message }))
+  /* Promise reject for status code 400 and 500 */
+  if (response.status === 408 || response.status >= 500) {
+    return Promise.reject(response)
   }
 
-  result = await response
-
-  return result
+  return response
 }

--- a/src/assets/react/api/form.js
+++ b/src/assets/react/api/form.js
@@ -14,14 +14,14 @@ import { api } from './api'
  * @param formId
  * @param filterData
  *
- * @returns {result: json}
+ * @returns Response
  *
  * @since 1.0
  */
-export const apiRequestAllEntryIds = async ({ formId, filterData }) => {
+export const apiRequestAllEntryIds = ({ formId, filterData }) => {
   const url = `${GPDF_BULK_GENERATOR.rest_url}/search/${formId}/entries`
 
-  const result = await api(url, {
+  return api(url, {
     method: 'POST',
     headers: {
       'Content-Type': 'application/json',
@@ -29,6 +29,4 @@ export const apiRequestAllEntryIds = async ({ formId, filterData }) => {
     },
     body: JSON.stringify(filterData)
   })
-
-  return result.json()
 }

--- a/src/assets/react/api/pdf.js
+++ b/src/assets/react/api/pdf.js
@@ -14,14 +14,14 @@ import { api } from './api'
  * @param path
  * @param concurrency
  *
- * @returns {result: json}
+ * @returns Response
  *
  * @since 1.0
  */
-export const apiRequestSessionId = async ({ path, concurrency }) => {
+export const apiRequestSessionId = ({ path, concurrency }) => {
   const url = `${GPDF_BULK_GENERATOR.rest_url}/generator/register`
 
-  const result = await api(url, {
+  return api(url, {
     method: 'POST',
     headers: {
       'Content-Type': 'application/json',
@@ -29,8 +29,6 @@ export const apiRequestSessionId = async ({ path, concurrency }) => {
     },
     body: JSON.stringify({ 'path': path, 'concurrency': concurrency })
   })
-
-  return result.json()
 }
 
 /**
@@ -39,15 +37,14 @@ export const apiRequestSessionId = async ({ path, concurrency }) => {
  * @param listItem
  * @param signal
  *
- * @returns {result: object}
+ * @returns Response
  *
  * @since 1.0
  */
-export const apiRequestGeneratePdf = async ({ listItem, signal }) => {
-
+export const apiRequestGeneratePdf = ({ listItem, signal }) => {
   const url = `${GPDF_BULK_GENERATOR.rest_url}/generator/create`
 
-  const result = await api(url, {
+  return api(url, {
     method: 'POST',
     signal,
     headers: {
@@ -56,29 +53,25 @@ export const apiRequestGeneratePdf = async ({ listItem, signal }) => {
     },
     body: JSON.stringify(listItem)
   })
-
-  return result
 }
 
 /**
  * Fetch API request to generate PDF zip file (POST)
  *
- * @param sessionId
+ * @param string sessionId
  *
- * @returns {result: json}
+ * @returns Response
  *
  * @since 1.0
  */
-export const apiRequestGeneratePdfZip = async sessionId => {
+export const apiRequestGeneratePdfZip = sessionId => {
   const url = `${GPDF_BULK_GENERATOR.rest_url}/generator/zip/${sessionId}`
 
-  const result = await api(url, {
+  return api(url, {
     method: 'POST',
     headers: {
       'Content-Type': 'application/json',
       'X-WP-Nonce': GPDF_BULK_GENERATOR.nonce
     }
   })
-
-  return result.json()
 }

--- a/src/assets/react/sagas/form.js
+++ b/src/assets/react/sagas/form.js
@@ -1,7 +1,7 @@
 /* Dependencies */
 import { retry, takeLatest, put } from 'redux-saga/effects'
 
-/* Action Types */
+/* Redux Action Types */
 import {
   GET_SELECTED_ENTRY_IDS,
   GET_SELECTED_ENTRY_IDS_SUCCESS,
@@ -20,9 +20,15 @@ import { apiRequestAllEntryIds } from '../api/form'
 
 export function* getSelectedEntryIds(payload) {
   try {
-    const result = yield retry(3, 3000, apiRequestAllEntryIds, payload)
+    const response = yield retry(3, 3000, apiRequestAllEntryIds, payload)
 
-    yield put({ type: GET_SELECTED_ENTRY_IDS_SUCCESS , payload: result })
+    if(!response.ok) {
+      throw response
+    }
+
+    const responseBody = yield response.json()
+
+    yield put({ type: GET_SELECTED_ENTRY_IDS_SUCCESS , payload: responseBody })
   } catch(error) {
     yield put({ type: GET_SELECTED_ENTRY_IDS_FAILED, payload: 'Error occured. Something went wrong..' })
   }


### PR DESCRIPTION
Rewrite how the fetch wrapper works so that we can retry on specific error codes only, but still throw an error for all other status codes. This gives us much greater control over how errors are handled for every request made, as well has how we handle the response body for every API request.