### PR TITLE
Prevent the enter key default action

### DIFF
--- a/assets/react/components/PopUp/PopUp.js
+++ b/assets/react/components/PopUp/PopUp.js
@@ -41,23 +41,44 @@ export class PopUp extends React.Component {
    * @since 1.0
    */
   componentDidMount () {
-    document.addEventListener('keydown', this.escapeKeyListener)
+    document.addEventListener('keydown', this.keyListener)
   }
 
   /**
-   * Listen if 'escape' key is pressed from the keyboard
-   *
-   * @param e
+   * Cleanup our document event listeners
    *
    * @since 1.0
    */
-  escapeKeyListener = e => {
-    const escapeKey = 27
-    const { fatalError, history } = this.props
+  componentWillUnmount () {
+    document.removeEventListener('keydown', this.keyListener)
+  }
 
-    /* 'escape' key is pressed */
-    if (e.keyCode === escapeKey) {
-      cancelModal({ e, fatalError, history })
+  /**
+   * Handle key presses from the keyboard
+   *
+   * @param e: object
+   *
+   * @since 1.0
+   */
+  keyListener = e => {
+    const { modal, fatalError, history } = this.props
+
+    /* Don't handle keys if the modal is currently closed */
+    if (!modal) {
+      return
+    }
+
+    switch(e.key) {
+      case 'Escape':
+        cancelModal({ e, fatalError, history })
+        break
+
+      case 'Enter':
+        /* Skip this if on Step 1 (handled there) */
+        if (history.location.pathname !== '/step/1') {
+          e.preventDefault()
+        }
+        break
     }
   }
 

--- a/assets/react/components/Steps/Step1.js
+++ b/assets/react/components/Steps/Step1.js
@@ -60,6 +60,7 @@ export class Step1 extends React.Component {
    */
   componentDidMount () {
     document.addEventListener('focus', this.handleFocus, true)
+    document.addEventListener('keypress', this.handleEnter)
   }
 
   /**
@@ -69,6 +70,7 @@ export class Step1 extends React.Component {
    */
   componentWillUnmount () {
     document.removeEventListener('focus', this.handleFocus, true)
+    document.removeEventListener('keypress', this.handleEnter)
   }
 
   /**
@@ -83,6 +85,19 @@ export class Step1 extends React.Component {
   handleFocus = e => {
     if (!this.container.contains(e.target)) {
       this.container.focus()
+    }
+  }
+
+  /**
+   * Handle 'enter' key press from the keyboard
+   *
+   * @param e
+   *
+   * @since 1.0
+   */
+  handleEnter = e => {
+    if (e.key === 'Enter') {
+      this.build(e)
     }
   }
 

--- a/tests/js-unit/react/components/PopUp/PopUp.test.js
+++ b/tests/js-unit/react/components/PopUp/PopUp.test.js
@@ -9,7 +9,7 @@ describe('/react/components/PopUp/ - PopUp.js', () => {
   let component
   let e
   let map = {}
-  let escapeKeyListener
+  let keyListener
   let fatalError = false
   let modal = true
   let inst
@@ -18,20 +18,31 @@ describe('/react/components/PopUp/ - PopUp.js', () => {
 
   describe('Lifecycle methods - ', () => {
 
+    let addEventListenerMock
+    let removeEventListenerMock
+
     beforeEach(() => {
       wrapper = shallow(<PopUp fatalError={fatalError} modal={modal} history={historyMock} />)
+      addEventListenerMock = document.addEventListener = jest.fn((event, cb) => map[event] = cb)
+      removeEventListenerMock = document.removeEventListener = jest.fn((event, cb) => map[event] = cb)
       inst = wrapper.instance()
     })
 
     test('componentDidMount() - Assign keyword listener to document on mount', () => {
       // Mocked functions
-      document.addEventListener = jest.fn((event, cb) => map[event] = cb)
-      escapeKeyListener = jest.spyOn(inst, 'escapeKeyListener')
+      keyListener = jest.spyOn(inst, 'keyListener').mockImplementation(() => {})
       inst.componentDidMount()
       /* Simulate event */
-      map.keydown({ key: 'Escape', keycode: 27 })
+      map.keydown()
 
-      expect(escapeKeyListener).toHaveBeenCalledTimes(1)
+      expect(addEventListenerMock).toHaveBeenCalledTimes(1)
+      expect(keyListener).toHaveBeenCalledTimes(1)
+    })
+
+    test('componentWIllUnmount - Cleanup our document event listeners', () => {
+      inst.componentWillUnmount()
+
+      expect(removeEventListenerMock).toHaveBeenCalledTimes(1)
     })
   })
 
@@ -42,11 +53,42 @@ describe('/react/components/PopUp/ - PopUp.js', () => {
       inst = wrapper.instance()
     })
 
-    test('escapeKeyListener() - Listen if \'escape\' key is pressed from the keyboard', () => {
-      e = { keyCode: 27, preventDefault () {} }
-      inst.escapeKeyListener(e)
+    test('keyListener() - Handle key presses from the keyboard (Escape)', () => {
+      e = { key: 'Escape', preventDefault () {} }
+      inst.keyListener(e)
 
       expect(historyMock.push.mock.calls.length).toBe(1)
+    })
+
+    test('keyListener() - Handle key presses from the keyboard (Enter - condition: true)', () => {
+      e = { key: 'Enter', preventDefault: jest.fn() }
+      inst.keyListener(e)
+
+      expect(e.preventDefault).toHaveBeenCalledTimes(1)
+
+      wrapper = shallow(<PopUp fatalError={fatalError} modal={modal} history={{ push: jest.fn(), location: { pathname: '/step/1' } }} />)
+      inst = wrapper.instance()
+      inst.keyListener(e)
+
+      expect(e.preventDefault).toHaveBeenCalledTimes(1)
+    })
+
+    test('keyListener() - Handle key presses from the keyboard (Enter - condition: false)', () => {
+      e = { key: 'Enter', preventDefault: jest.fn() }
+      wrapper = shallow(<PopUp fatalError={fatalError} modal={modal} history={{ push: jest.fn(), location: { pathname: '/step/1' } }} />)
+      inst = wrapper.instance()
+      inst.keyListener(e)
+
+      expect(e.preventDefault).toHaveBeenCalledTimes(0)
+    })
+
+    test('keyListener() - Don\'t handle keys if the modal is currently closed', () => {
+      e = { key: 'Escape', preventDefault () {} }
+      wrapper = shallow(<PopUp fatalError={fatalError} modal={false} history={historyMock} />)
+      inst = wrapper.instance()
+      inst.keyListener(e)
+
+      expect(historyMock.push.mock.calls.length).toBe(0)
     })
   })
 

--- a/tests/js-unit/react/components/Steps/Step1.test.js
+++ b/tests/js-unit/react/components/Steps/Step1.test.js
@@ -24,6 +24,7 @@ describe('/react/components/Steps/ - Step1.js', () => {
     let addEventListenerMock
     let removeEventListenerMock
     let handleFocus
+    let handleEnter
 
     beforeEach(() => {
       wrapper = shallow(
@@ -38,26 +39,28 @@ describe('/react/components/Steps/ - Step1.js', () => {
       )
       addEventListenerMock = document.addEventListener = jest.fn((event, cb) => map[event] = cb)
       removeEventListenerMock = document.removeEventListener = jest.fn((event, cb) => map[event] = cb)
+      jest.spyOn(window, 'alert').mockImplementation(() => {})
       inst = wrapper.instance()
       handleFocus = jest.spyOn(inst, 'handleFocus').mockImplementation(() => {})
+      handleEnter = jest.spyOn(inst, 'handleEnter')
     })
 
     test('componentDidMount() - On mount, Add focus event to document', () => {
+      e = { key: 'Enter', preventDefault () {} }
       inst.componentDidMount()
-      /* Simulate keyboard pressKey */
+      /* Simulate keyboard press */
       map.focus()
+      map.keypress(e)
 
-      expect(addEventListenerMock).toHaveBeenCalledTimes(1)
+      expect(addEventListenerMock).toHaveBeenCalledTimes(2)
       expect(handleFocus).toHaveBeenCalledTimes(1)
+      expect(handleEnter).toHaveBeenCalledTimes(1)
     })
 
     test('componentWillUnmount() - Cleanup our document event listeners', () => {
       inst.componentWillUnmount()
-      /* Simulate keyboard pressKey */
-      map.focus()
 
-      expect(removeEventListenerMock).toHaveBeenCalledTimes(1)
-      expect(handleFocus).toHaveBeenCalledTimes(1)
+      expect(removeEventListenerMock).toHaveBeenCalledTimes(2)
     })
   })
 
@@ -79,11 +82,19 @@ describe('/react/components/Steps/ - Step1.js', () => {
 
     test('handleFocus() - This keeps the focus from jumping outside our container (contition: true)', () => {
       const container = { contains: jest.fn(), focus: jest.fn() }
-      const e = { target: {} }
+      e = { target: {} }
       inst.container = container
       inst.handleFocus(e)
 
       expect(container.focus).toHaveBeenCalledTimes(1)
+    })
+
+    test('handleEnter() - Handle \'enter\' key press from the keyboard', () => {
+      e = { key: 'Enter'}
+      const build = jest.spyOn(inst, 'build').mockImplementation(() => {})
+      inst.handleEnter(e)
+
+      expect(build).toHaveBeenCalledTimes(1)
     })
 
     test('build() - Request to build the bulk PDF download (active pdf)', () => {


### PR DESCRIPTION
This stops Gravity Forms Bulk Action form submitting and prevents an alert.