### PR TITLE
Before beginning the stream, close all output buffering

### DIFF
--- a/src/Api/Generator/Download.php
+++ b/src/Api/Generator/Download.php
@@ -122,6 +122,11 @@ class Download implements ApiEndpointRegistration {
 				return new \WP_Error( 'zip_not_found', '', [ 'status' => 404 ] );
 			}
 
+			/* Close any active buffers before outputting */
+			while ( apply_filters( 'gfpdf_bulk_generator_close_active_buffers', true ) && ob_get_level() ) {
+				ob_end_clean();
+			}
+
 			/* Send zip file to browser */
 			if ( ! headers_sent() ) {
 				header( 'Content-Type: application/zip' );
@@ -132,9 +137,6 @@ class Download implements ApiEndpointRegistration {
 			$stream = $this->filesystem->readStream( $this->filesystem->get_zip_path() );
 			while ( ! feof( $stream ) ) {
 				echo fread( $stream, 2048 );
-				if ( ob_get_level() ) {
-					ob_flush();
-				}
 				flush();
 			}
 

--- a/tests/phpunit/unit-tests/Api/Generator/DownloadTest.php
+++ b/tests/phpunit/unit-tests/Api/Generator/DownloadTest.php
@@ -114,6 +114,7 @@ class DownloadTest extends DefaultApiTests {
 		$request = new \WP_REST_Request( 'GET', $this->rest_route );
 		$request->set_query_params( [ 'sessionId' => self::SESSION_ID ] );
 
+		add_filter( 'gfpdf_bulk_generator_close_active_buffers', '__return_false' );
 		ob_start();
 		$this->endpoint->response( $request );
 		$this->assertStringStartsWith( 'content1', ob_get_clean() );


### PR DESCRIPTION
This resolves an issue downloading the zip file in full on some hosting providers.